### PR TITLE
Fix typo

### DIFF
--- a/api.json
+++ b/api.json
@@ -5681,7 +5681,7 @@
 		},
 		{
 			"id": 35,
-			"name": "KANA_COMMON_CAHRS",
+			"name": "KANA_COMMON_CHARS",
 			"kind": 32,
 			"kindString": "Variable",
 			"flags": {
@@ -5694,7 +5694,7 @@
 			},
 			"sources": [
 				{
-					"fileName": "const/KANA_COMMON_CAHRS.ts",
+					"fileName": "const/KANA_COMMON_CHARS.ts",
 					"line": 7,
 					"character": 30
 				}

--- a/const/KANA_COMMON_CAHRS.ts
+++ b/const/KANA_COMMON_CAHRS.ts
@@ -1,7 +1,2 @@
-/**
- * 濁点／半濁点(結合文字含む)・長音符
- *
- * [゛゜ー]
- *
- */
-export const KANA_COMMON_CAHRS = '\u3099-\u309C\u30FC';
+// This is for backward compatibility.
+export { KANA_COMMON_CHARS as KANA_COMMON_CAHRS } from './KANA_COMMON_CHARS';

--- a/const/KANA_COMMON_CHARS.ts
+++ b/const/KANA_COMMON_CHARS.ts
@@ -1,0 +1,7 @@
+/**
+ * 濁点／半濁点(結合文字含む)・長音符
+ *
+ * [゛゜ー]
+ *
+ */
+export const KANA_COMMON_CHARS = '\u3099-\u309C\u30FC';

--- a/fn/isOnlyHiragana.ts
+++ b/fn/isOnlyHiragana.ts
@@ -1,5 +1,5 @@
 import { HIRAGANA_CHARS } from '../const/HIRAGANA_CHARS';
-import { KANA_COMMON_CAHRS } from '../const/KANA_COMMON_CAHRS';
+import { KANA_COMMON_CHARS } from '../const/KANA_COMMON_CHARS';
 
 import isOnly from './isOnly';
 
@@ -11,5 +11,5 @@ import isOnly from './isOnly';
  * @param str 対象の文字列
  */
 export default function(str: string): boolean {
-  return isOnly(str, HIRAGANA_CHARS + KANA_COMMON_CAHRS);
+  return isOnly(str, HIRAGANA_CHARS + KANA_COMMON_CHARS);
 }

--- a/fn/isOnlyKatakana.ts
+++ b/fn/isOnlyKatakana.ts
@@ -1,4 +1,4 @@
-import { KANA_COMMON_CAHRS } from '../const/KANA_COMMON_CAHRS';
+import { KANA_COMMON_CHARS } from '../const/KANA_COMMON_CHARS';
 import { KATAKANA_CHARS } from '../const/KATAKANA_CHARS';
 
 import isOnly from './isOnly';
@@ -11,5 +11,5 @@ import isOnly from './isOnly';
  * @param str 対象の文字列
  */
 export default function(str: string): boolean {
-  return isOnly(str, KATAKANA_CHARS + KANA_COMMON_CAHRS);
+  return isOnly(str, KATAKANA_CHARS + KANA_COMMON_CHARS);
 }


### PR DESCRIPTION
Probably `KANA_COMMON_CAHRS` is typo of `KANA_COMMON_CHARS`.
If it is intended, please close this pull request.